### PR TITLE
replace deprecated call

### DIFF
--- a/src/main/java/redis/embedded/util/JarUtil.java
+++ b/src/main/java/redis/embedded/util/JarUtil.java
@@ -1,11 +1,11 @@
 package redis.embedded.util;
 
-import com.google.common.io.Files;
 import com.google.common.io.Resources;
 import org.apache.commons.io.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
 public class JarUtil {
 
@@ -21,7 +21,7 @@ public class JarUtil {
     }
 
     public static File extractFileFromJar(String path) throws IOException {
-        File tmpDir = Files.createTempDir();
+        File tmpDir = Files.createTempDirectory(null).toFile();
         tmpDir.deleteOnExit();
 
         File file = new File(tmpDir, path);


### PR DESCRIPTION
replace deprecated call to Guava's `Files.createTempDir()`